### PR TITLE
Downgrade TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-dom": "^19.1.0",
         "react-grid-layout": "^1.5.1",
         "react-resizable": "^3.0.5",
-        "typescript": "^5.8.3"
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
         "react-scripts": "latest"
@@ -18874,9 +18874,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-5m2f/HYQdkWXNoKGdzFFXwmlmR7BfrpsbR9f7DmqDveoxu48UUfZo0Sy0RKZ77N8DfszCFAaj6MqFmoVoeAQ1A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.1.0",
     "react-grid-layout": "^1.5.1",
     "react-resizable": "^3.0.5",
-    "typescript": "^5.8.3"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- downgrade TypeScript to 4.9.5 for compatibility with CRA

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9be34348325b211fdef3be88e8e